### PR TITLE
Fixed example assignation

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -19,7 +19,7 @@ func main() {
 	logger, _ := zap.NewProduction()
 
 	// Wrap a NewTee to send log messages to both your main logger and to rollbar
-	logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	logger = logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		return zapcore.NewTee(core, rollbarCore)
 	}))
 


### PR DESCRIPTION
Oh man, this took me a while. 
So the example is wrong, you need to assign newly created logger as logger to be able to later act upon the new one. 
Please merge this to prevent further wtfs :)
Cheers!  